### PR TITLE
色分け設定スクリプトの再実装

### DIFF
--- a/src/emph/Footy2.js
+++ b/src/emph/Footy2.js
@@ -1,0 +1,109 @@
+var Footy2 =
+  {
+    RGB:
+      function(r, g, b)
+      {
+        var byte = function(x) { return x & 0xFF; };
+        return byte(r) | (byte(g) << 8) | (byte(b) << 16);
+      },
+
+    PERMIT_LEVEL:
+      function(x)
+      {
+        return 1 << x;
+      },
+
+    Consts =
+      {
+        // EmpMode:
+        EMP_INVALIDITY    : 0,
+        EMP_WORD          : 1,
+        EMP_LINE_AFTER    : 2,
+        EMP_LINE_BETWEEN  : 3,
+        EMP_MULTI_BETWEEN : 4,
+
+        // EmpType:
+        EMPFLAG_BOLD   : 0x00000001,
+        EMPFLAG_NON_CS : 0x00000002,
+        EMPFLAG_HEAD   : 0x00000004,
+
+        // IndependentFlags:
+        EMP_IND_PARENTHESIS      :  0x00000001,
+        EMP_IND_BRACE            :  0x00000002,
+        EMP_IND_ANGLE_BRACKET    :  0x00000004,
+        EMP_IND_SQUARE_BRACKET   :  0x00000008,
+        EMP_IND_QUOTATION        :  0x00000010,
+        EMP_IND_UNDERBAR         :  0x00000020,
+        EMP_IND_OPERATORS        :  0x00000040,
+        EMP_IND_OTHER_ASCII_SIGN :  0x00000080,
+        EMP_IND_NUMBER           :  0x00000100,
+        EMP_IND_CAPITAL_ALPHABET :  0x00000200,
+        EMP_IND_SMALL_ALPHABET   :  0x00000400,
+        EMP_IND_SPACE            :  0x00001000,
+        EMP_IND_FULL_SPACE       :  0x00002000,
+        EMP_IND_TAB              :  0x00004000,
+        EMP_IND_JAPANESE         :  0x00010000,
+        EMP_IND_KOREAN           :  0x00020000,
+        EMP_IND_EASTUROPE        :  0x00040000,
+        EMP_IND_OTHERS           :  0x80000000,
+        EMP_IND_ASCII_SIGN       :  0x000000FF,
+        EMP_IND_ASCII_LETTER     :  0x00000F00,
+        EMP_IND_BLANKS           :  0x0000F000,
+        EMP_IND_OTHER_CHARSETS   :  0xFFFF0000,
+        EMP_IND_ALLOW_ALL        :  0xFFFFFFFF
+      },
+
+    Emphasis:
+      function()
+      {
+        this.list = [];
+        this.config =
+          {
+            type          : Footy2.Consts.EMP_WORD,
+            flags         : 0,
+            level         : 0,
+            permission    : 0x00000001,
+            independence  : Footy2.Consts.EMP_IND_ALLOW_ALL,
+            color         : 0x000000
+          };
+
+        this.add =
+          function(s1, s2)
+          {
+            this.list.push(
+              {
+                s1: s1,
+                s2: s2,
+                type          : this.config.type,
+                flags         : this.config.flags,
+                level         : this.config.level,
+                permission    : this.config.permission,
+                independence  : this.config.independence,
+                color         : this.config.color
+              });
+          };
+
+        var emph_to_string =
+          function(emph)
+          {
+            return (
+              [
+                emph.s1,
+                emph.s2,
+                emph.type,
+                emph.flags,
+                emph.level,
+                emph.permission,
+                emph.independence,
+                emph.color
+              ].join("\t")
+              );
+          };
+
+        this.toString =
+          function()
+          {
+            return this.list.map(emph_to_string).join("\n");
+          };
+      }
+  };

--- a/src/emph/extension.ini
+++ b/src/emph/extension.ini
@@ -1,0 +1,3 @@
+[lang]
+.hsp = "hsp3"
+.as  = "hsp3"

--- a/src/emph/hsp3.js
+++ b/src/emph/hsp3.js
@@ -1,0 +1,51 @@
+function emphLang_hsp3()
+{
+  var lv =
+    {
+      comment   : 1,
+      string    : 2,
+      char      : 3,
+      symbol    : 15,
+      command   : 16,
+      macro     : 17,
+      userdef   : 18,
+      preproc   : 19,
+      label     : 20,
+      reserved  : 21
+    };
+
+  var keywords =
+    {
+      intSttmList:
+        "screen,buffer,bgscr,dialog,gsel,gradf,gcopy,gzoom,gmode,groll,grect,grotate,gsquare,width,picload,bmpsave,color,syscolor,pget,pos,cls,font,sysfont,redraw,palcolor,hsvcolor,palette,celput,celload,celdiv,mes,print,boxf,line,circle,pset,title,objsize,objsel,clrobj,objprm,objmode,objenable,objimage,objskip,button,listbox,chkbox,combox,input,mesbox,axobj,winobj,if,else,on,goto,exgoto,gosub,return,wait,await,end,stop,onexit,onerror,onkey,onclick,oncmd,repeat,foreach,loop,break,continue,dim,sdim,dimtype,dup,dupptr,mref,newmod,delmod,newlab,newcom,delcom,querycom,mcall,comres,comevent,comevarg,comevdisp,sarrayconv,poke,wpoke,lpoke,getstr,cnvstow,memcpy,memset,memexpand,split,strrep,notesel,noteunsel,noteadd,notedel,noteload,notesave,noteget,exist,dirlist,chdir,delete,mkdir,bsave,bload,bcopy,memfile,mouse,getkey,stick,mmload,mmplay,mmstop,sendmsg,exec,randomize,run,chgdisp,mci,chdpm,assert,logmes",
+
+      intFuncList:
+        "varptr,vartype,varuse,libptr,callfunc,ginfo,objinfo,dirinfo,sysinfo,noteinfo,gettime,int,str,double,instr,strmid,strlen,getpath,strf,cnvwtos,strtrim,peek,wpeek,lpeek,length,length2,length3,length4,rnd,limit,limitf,sin,cos,tan,atan,abs,absf,sqrt,expf,logf",
+
+      intSysvarList:
+        "err,mousex,mousey,mousew,hwnd,hinstance,hdc,looplev,sublev,system,hspstat,hspver,stat,refstr,refdval,cnt,strsize,thismod,iparam,wparam,lparam",
+
+      reserved:
+        ""
+    }
+
+  emph = new Footy2.Emphasis();
+  with (Footy2) {
+    with (emph.emph) {
+      flags =
+        EMPFLAG_NON_CS;
+      independence =
+        EMP_IND_ASCII_SIGN | EMP_IND_BLANKS;
+
+      var intCmdList =
+        ( keywords.intSttmList
+        + "," + keywords.intFuncList
+        + "," + keywords.intSysvarList
+        );
+      for (cmd : intCmdList.split(",")) {
+        add(cmd, null);
+      }
+    }
+  }
+  return emph.toString();
+}


### PR DESCRIPTION
- 拡張子から設定ファイルへの対応も外部のファイルに書く。
## メモ
- javascript を実行することで色分け設定データを生成し、それを読み込んで Footy に設定する、という予定。
